### PR TITLE
LOGMLE - Fix argo metaflow retry integration

### DIFF
--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,6 +162,7 @@ def step(
             retry_count,
         )
     else:
+        echo(f"Custom log in step.....{step_name}")
         task.run_step(
             step_name,
             run_id,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -164,17 +164,14 @@ def step(
     else:
         from metaflow.datastore.exceptions import DataException
 
-        echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")        
-        try:
-            t_datastore = task.flow_datastore.get_task_datastore(
-                run_id=run_id,
-                step_name=step_name,
-                task_id=task_id,
-                allow_not_done=True,
-            )
-            retry_count = t_datastore.attempt
-        except DataException:
-            retry_count = 0
+        echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
+        t_datastore = task.flow_datastore.get_task_datastore(
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id,
+            allow_not_done=True,
+        )
+        retry_count = t_datastore.attempt
         echo_always(f"retry count: {retry_count}")
         task.run_step(
             step_name,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -174,8 +174,9 @@ def step(
                 step_name=step_name,
                 task_id=task_id,
             )
-            retry_count += getattr(t_datastore, "attempt", 0)
+            retry_count = getattr(t_datastore, "attempt", 0) + 1
         except DataException as e:
+            retry_count = 0
             echo_always(f"Warning: Failed to retrieve datastore. Exception: {e}")
         echo_always(f"retry count: {retry_count}")
         task.run_step(

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -169,9 +169,8 @@ def step(
             step_name=step_name,
             task_id=task_id
         )
-        retry_count = 0
-        if not latest_done_attempt == 0:
-            retry_count += latest_done_attempt
+        if latest_done_attempt:
+            retry_count = latest_done_attempt + 1
         echo_always(f"{latest_done_attempt=}")
         echo_always(f"{retry_count=}")
         # Not sure what are the side effects to this.

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -167,7 +167,9 @@ def step(
             step_name=step_name,
             task_id=task_id
         )
-        retry_count = latest_done_attempt + 1
+        retry_count = 0
+        if not latest_done_attempt == 0:
+            retry_count += latest_done_attempt
         echo_always(f"{latest_done_attempt=}")
         echo_always(f"{retry_count=}")
         # Not sure what are the side effects to this.

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -173,7 +173,7 @@ def step(
                 task_id=task_id,
             )
             echo_always(f"latest attempt number: {t_datastore.attempt}")
-            retry_count = t_datastore.attempt + 1
+            retry_count = getattr(t_datastore, "attempt", 0) + 1
         except DataException as e:
             retry_count = 0
             echo_always(f"This is a first ever run, Exception: {e}")

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,8 +162,15 @@ def step(
             retry_count,
         )
     else:
-        t_datastore = task.flow_datastore.get_task_datastore()
+        echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
+        t_datastore = task.flow_datastore.get_task_datastore(
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id
+        )
         echo_always(f"attempt: {t_datastore.attempt}")
+        retry_count = t_datastore.attempt if t_datastore.attempt else 0 
+        echo_always(f"retry count: {retry_count}")
         task.run_step(
             step_name,
             run_id,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -163,6 +163,7 @@ def step(
         )
     else:
         echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
+        echo_always(f"attempt: {task.flow_datastore.attempt}, ds_root: {task.flow_datastore.datastore_root}, ca_store: {task.flow_datastore.ca_store}")
         t_datastore = task.flow_datastore.get_task_datastore(
             run_id=run_id,
             step_name=step_name,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -166,7 +166,7 @@ def step(
             pathspecs=[f"{run_id}/{step_name}/{task_id}"],
             include_prior=True,
         )
-        latest_done_attempt = max([t.attempt for t in t_datastores], default=-1)  # default=-1, this is first run.
+        latest_done_attempt = max([t.attempt for t in t_datastores], default=-1)  # default=-1, when no successful done_attempts found.
         retry_count = latest_done_attempt + 1
         echo_always(f"{latest_done_attempt=}")
         echo_always(f"{retry_count=}")

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,7 +162,8 @@ def step(
             retry_count,
         )
     else:
-        echo_always(f"Custom log in step.....{step_name}")
+        t_datastore = task.flow_datastore.get_task_datastore()
+        echo_always(f"attempt: {t_datastore.attempt}")
         task.run_step(
             step_name,
             run_id,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -171,6 +171,7 @@ def step(
                 run_id=run_id,
                 step_name=step_name,
                 task_id=task_id,
+                allow_not_done=True
             )
             echo_always(f"latest attempt number: {t_datastore.attempt}")
             retry_count = getattr(t_datastore, "attempt", 0) + 1
@@ -178,6 +179,9 @@ def step(
             retry_count = 0
             echo_always(f"This is a first ever run, Exception: {e}")
         echo_always(f"retry count: {retry_count}")
+        # Not sure what are the side effects to this.
+        # if retry_count >= max_user_code_retries:
+        #     max_user_code_retries = retry_count
         task.run_step(
             step_name,
             run_id,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -168,6 +168,7 @@ def step(
         )
         latest_done_attempt = max([t.attempt for t in t_datastores], default=-1)  # default=-1, this is first run.
         retry_count = latest_done_attempt + 1
+        echo_always(f"{latest_done_attempt=}")
         echo_always(f"{retry_count=}")
         # Not sure what are the side effects to this.
         if retry_count >= max_user_code_retries:

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -170,7 +170,6 @@ def step(
             task_id=task_id,
             allow_not_done=True,  # hack to not run into DataException
         )
-        echo_always(f"data store metadata: {t_datastore.ds_metadata}")
         retry_count = t_datastore.attempt
         echo_always(f"retry count: {retry_count}")
         task.run_step(

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,7 +162,7 @@ def step(
             retry_count,
         )
     else:
-        echo(f"Custom log in step.....{step_name}")
+        echo_always(f"Custom log in step.....{step_name}")
         task.run_step(
             step_name,
             run_id,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -165,8 +165,6 @@ def step(
         from metaflow.datastore.exceptions import DataException
 
         echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
-        echo_always(f"ca_store: {task.flow_datastore.ca_store.TYPE}, {task.flow_datastore.datastore_root}")
-        echo_always(task.flow_datastore.ca_store)
         try:
             # this will hit exception on first run
             t_datastore = task.flow_datastore.get_task_datastore(

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,11 +162,11 @@ def step(
             retry_count,
         )
     else:
-        t_datastores = task.flow_datastore.get_task_datastores(
-            pathspecs=[f"{run_id}/{step_name}/{task_id}"],
-            include_prior=True,
+        latest_done_attempt = task.flow_datastore.get_latest_done_attempt(
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id
         )
-        latest_done_attempt = max([t.attempt for t in t_datastores], default=-1)  # default=-1, when no successful done_attempts found.
         retry_count = latest_done_attempt + 1
         echo_always(f"{latest_done_attempt=}")
         echo_always(f"{retry_count=}")

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -169,7 +169,8 @@ def step(
             t_datastore = task.flow_datastore.get_task_datastore(
                 run_id=run_id,
                 step_name=step_name,
-                task_id=task_id
+                task_id=task_id,
+                allow_not_done=True,
             )
             retry_count = t_datastore.attempt
         except DataException:

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,14 +162,18 @@ def step(
             retry_count,
         )
     else:
-        echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
-        t_datastore = task.flow_datastore.get_task_datastore(
-            run_id=run_id,
-            step_name=step_name,
-            task_id=task_id
-        )
-        echo_always(f"attempt: {t_datastore.attempt}")
-        retry_count = t_datastore.attempt if t_datastore.attempt else 0 
+        from metaflow.datastore.exceptions import DataException
+
+        echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")        
+        try:
+            t_datastore = task.flow_datastore.get_task_datastore(
+                run_id=run_id,
+                step_name=step_name,
+                task_id=task_id
+            )
+            retry_count = t_datastore.attempt
+        except DataException:
+            retry_count = 0
         echo_always(f"retry count: {retry_count}")
         task.run_step(
             step_name,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -163,7 +163,7 @@ def step(
         )
     else:
         echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
-        echo_always(f"attempt: {task.flow_datastore.attempt}, ds_root: {task.flow_datastore.datastore_root}, ca_store: {task.flow_datastore.ca_store}")
+        echo_always(f"ca_store: {task.flow_datastore.ca_store.TYPE}, {task.flow_datastore.datastore_root}")
         t_datastore = task.flow_datastore.get_task_datastore(
             run_id=run_id,
             step_name=step_name,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -168,7 +168,7 @@ def step(
             run_id=run_id,
             step_name=step_name,
             task_id=task_id,
-            allow_not_done=True,
+            allow_not_done=True,  # hack to not run into DataException
         )
         echo_always(f"data store metadata: {t_datastore.ds_metadata}")
         retry_count = t_datastore.attempt

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -172,10 +172,11 @@ def step(
                 step_name=step_name,
                 task_id=task_id,
             )
-            retry_count = getattr(t_datastore, "attempt", 0) + 1
+            echo_always(f"latest attempt number: {t_datastore.attempt}")
+            retry_count = t_datastore.attempt + 1
         except DataException as e:
             retry_count = 0
-            echo_always(f"Warning: Failed to retrieve datastore. Exception: {e}")
+            echo_always(f"This is a first ever run, Exception: {e}")
         echo_always(f"retry count: {retry_count}")
         task.run_step(
             step_name,

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -162,8 +162,6 @@ def step(
             retry_count,
         )
     else:
-        from metaflow.datastore.exceptions import DataException
-
         echo_always(f" run_id: {run_id}, step_name: {step_name}, task_id: {task_id}")
         t_datastore = task.flow_datastore.get_task_datastore(
             run_id=run_id,
@@ -171,6 +169,7 @@ def step(
             task_id=task_id,
             allow_not_done=True,
         )
+        echo_always(f"data store metadata: {t_datastore.ds_metadata}")
         retry_count = t_datastore.attempt
         echo_always(f"retry count: {retry_count}")
         task.run_step(

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -160,9 +160,6 @@ def step(
     )
     if latest_done_attempt:
         retry_count = latest_done_attempt + 1
-    # Not sure what are the side effects to this.
-    if retry_count >= max_user_code_retries:
-        max_user_code_retries = retry_count
 
     if clone_only:
         task.clone_only(

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+from typing import Optional
 
 from .. import metaflow_config
 
@@ -67,12 +68,12 @@ class FlowDataStore(object):
     def datastore_root(self):
         return self._storage_impl.datastore_root
 
-    def get_latest_done_attempt(self, run_id, step_name, task_id) -> int:
+    def get_latest_done_attempt(self, run_id, step_name, task_id) -> Optional[int]:
         t_datastores = self.get_task_datastores(
             pathspecs=[f"{run_id}/{step_name}/{task_id}"],
             include_prior=True
         )
-        return max([t.attempt for t in t_datastores], default=0)  # returns default, if this was a first attempt.
+        return max([t.attempt for t in t_datastores], default=None)  # returns default, if this was a first attempt.
 
     def get_task_datastores(
         self,

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -72,7 +72,7 @@ class FlowDataStore(object):
             pathspecs=[f"{run_id}/{step_name}/{task_id}"],
             include_prior=True
         )
-        return max([t.attempt for t in t_datastores], default=-1)  # default=-1, when no successful done_attempts found.
+        return max([t.attempt for t in t_datastores], default=0)  # returns default, if this was a first attempt.
 
     def get_task_datastores(
         self,

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -67,6 +67,13 @@ class FlowDataStore(object):
     def datastore_root(self):
         return self._storage_impl.datastore_root
 
+    def get_latest_done_attempt(self, run_id, step_name, task_id) -> int:
+        t_datastores = self.get_task_datastores(
+            pathspecs=[f"{run_id}/{step_name}/{task_id}"],
+            include_prior=True
+        )
+        return max([t.attempt for t in t_datastores], default=-1)  # default=-1, when no successful done_attempts found.
+
     def get_task_datastores(
         self,
         run_id=None,

--- a/metaflow/mflog/save_logs.py
+++ b/metaflow/mflog/save_logs.py
@@ -39,7 +39,7 @@ def save_logs():
     # Use inferred attempt - to save task_stdout.log and task_stderr.log
     latest_done_attempt = flow_datastore.get_latest_done_attempt(run_id=run_id, step_name=step_name, task_id=task_id)
     task_datastore = flow_datastore.get_task_datastore(
-        run_id, step_name, task_id, int(latest_done_attempt), mode="w"
+        run_id, step_name, task_id, latest_done_attempt, mode="w"
     )
 
     try:

--- a/metaflow/mflog/save_logs.py
+++ b/metaflow/mflog/save_logs.py
@@ -21,7 +21,6 @@ def save_logs():
 
     # these env vars are set by mflog.mflog_env
     pathspec = os.environ["MF_PATHSPEC"]
-    attempt = os.environ["MF_ATTEMPT"]
     ds_type = os.environ["MF_DATASTORE"]
     ds_root = os.environ.get("MF_DATASTORE_ROOT")
     paths = (os.environ["MFLOG_STDOUT"], os.environ["MFLOG_STDERR"])
@@ -37,8 +36,10 @@ def save_logs():
     flow_datastore = FlowDataStore(
         flow_name, None, storage_impl=storage_impl, ds_root=ds_root
     )
+    # Use inferred attempt - to save task_stdout.log and task_stderr.log
+    latest_done_attempt = flow_datastore.get_latest_done_attempt(run_id=run_id, step_name=step_name, task_id=task_id)
     task_datastore = flow_datastore.get_task_datastore(
-        run_id, step_name, task_id, int(attempt), mode="w"
+        run_id, step_name, task_id, int(latest_done_attempt), mode="w"
     )
 
     try:

--- a/metaflow/mflog/save_logs.py
+++ b/metaflow/mflog/save_logs.py
@@ -21,7 +21,8 @@ def save_logs():
 
     # these env vars are set by mflog.mflog_env
     pathspec = os.environ["MF_PATHSPEC"]
-    attempt = os.environ["MF_ATTEMPT"]
+    # Not using this anymore, since we infer attempt number from flowdatastore
+    # attempt = os.environ["MF_ATTEMPT"]
     ds_type = os.environ["MF_DATASTORE"]
     ds_root = os.environ.get("MF_DATASTORE_ROOT")
     paths = (os.environ["MFLOG_STDOUT"], os.environ["MFLOG_STDERR"])
@@ -37,8 +38,14 @@ def save_logs():
     flow_datastore = FlowDataStore(
         flow_name, None, storage_impl=storage_impl, ds_root=ds_root
     )
+    # Use inferred attempt - to save task_stdout.log and task_stderr.log
+    t_datastores = flow_datastore.get_task_datastores(
+        pathspecs=[pathspec],
+        include_prior=True,
+    )
+    latest_attempt = max([ds.attempt for ds in t_datastores], default=0)
     task_datastore = flow_datastore.get_task_datastore(
-        run_id, step_name, task_id, int(attempt), mode="w"
+        run_id, step_name, task_id, int(latest_attempt), mode="w"
     )
 
     try:

--- a/metaflow/mflog/save_logs.py
+++ b/metaflow/mflog/save_logs.py
@@ -21,8 +21,7 @@ def save_logs():
 
     # these env vars are set by mflog.mflog_env
     pathspec = os.environ["MF_PATHSPEC"]
-    # Not using this anymore, since we infer attempt number from flowdatastore
-    # attempt = os.environ["MF_ATTEMPT"]
+    attempt = os.environ["MF_ATTEMPT"]
     ds_type = os.environ["MF_DATASTORE"]
     ds_root = os.environ.get("MF_DATASTORE_ROOT")
     paths = (os.environ["MFLOG_STDOUT"], os.environ["MFLOG_STDERR"])
@@ -38,14 +37,8 @@ def save_logs():
     flow_datastore = FlowDataStore(
         flow_name, None, storage_impl=storage_impl, ds_root=ds_root
     )
-    # Use inferred attempt - to save task_stdout.log and task_stderr.log
-    t_datastores = flow_datastore.get_task_datastores(
-        pathspecs=[pathspec],
-        include_prior=True,
-    )
-    latest_attempt = max([ds.attempt for ds in t_datastores], default=0)
     task_datastore = flow_datastore.get_task_datastore(
-        run_id, step_name, task_id, int(latest_attempt), mode="w"
+        run_id, step_name, task_id, int(attempt), mode="w"
     )
 
     try:


### PR DESCRIPTION
## Problem

https://github.com/deliveryhero/logistics-ds-metaflow-ext/issues/108#issue-2832910761
 
## Solution

This PR,modifies the step cli command to infer retry_count from `flow_datastore` class. Looks like this class, holds all the information about underlying datastore and run artifiacts.

- Adds a method that infers latest done attempt of a task
- Remove MF_ATTEMPT from `mflog.save_logs` python script.

## New Behaviour

Previously `argo retry --node <>` would overwrite previously run attepmts, Now it would add artifacts as it was new attempt.

Fixes: https://github.com/deliveryhero/logistics-ds-metaflow-ext/issues/108

Slack Discussion: https://outerbounds-community.slack.com/archives/C020U025QJK/p1737483912784969

### Testing and Limitations
- [Cannot Retry more than 6 times.](https://github.com/Netflix/metaflow/blob/5c960eaff1ae486f503b37177f03cc1419b5571d/metaflow/metaflow_config.py#L510)

Use this branch on dummy model to test this:
- https://github.com/deliveryhero/logistics-ds-dummy-project/pull/145

### Validation & QA
- https://github.com/dhpikolo/metaflow/pull/1#issuecomment-2666295040)

Documentation:
- https://github.com/deliveryhero/logistics-ds-metaflow-ext/pull/110
